### PR TITLE
feat: トークン操作用 Service を実装

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-sql-driver/mysql v1.8.1
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -23,6 +23,8 @@ github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpv
 github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
 github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIxtHqx8aGss=
 github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=

--- a/backend/pkg/auth/token.go
+++ b/backend/pkg/auth/token.go
@@ -1,0 +1,228 @@
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+)
+
+const (
+	// アクセストークンの有効期限 (1時間)
+	accessTokenExpire = time.Hour
+	// リフレッシュトークンの有効期限 (1週間)
+	refreshTokenExpire = time.Hour * 24 * 7
+)
+
+type clock interface {
+	Now() time.Time
+}
+
+type Token struct {
+	Exp   time.Time
+	Iat   time.Time
+	Iss   string
+	Sub   string
+	Aud   jwt.ClaimStrings
+	Jti   string
+	Uname string
+}
+
+type TokenService struct {
+	store         TokenStore
+	issuer        string
+	audience      string
+	accessSecret  []byte
+	refreshSecret []byte
+	clock         clock
+}
+
+type TokenStore interface {
+	// jtiを保存する
+	SaveJTI(jti string) error
+	// jtiが存在するか確認する
+	ExistsJTI(jti string) (bool, error)
+}
+
+// TokenServiceを生成する
+func NewTokenService(store TokenStore, clock clock) (*TokenService, error) {
+	iss, ok := os.LookupEnv("TOKEN_ISSUER")
+	if !ok {
+		return nil, errors.New("TOKEN_ISSUER is not set")
+	}
+	aud, ok := os.LookupEnv("TOKEN_AUDIENCE")
+	if !ok {
+		return nil, errors.New("TOKEN_AUDIENCE is not set")
+	}
+	as, ok := os.LookupEnv("TOKEN_ACCESS_SECRET")
+	if !ok {
+		return nil, errors.New("TOKEN_ACCESS_SECRET is not set")
+	}
+	rs, ok := os.LookupEnv("TOKEN_REFRESH_SECRET")
+	if !ok {
+		return nil, errors.New("TOKEN_REFRESH_SECRET is not set")
+	}
+	return &TokenService{
+		store:         store,
+		issuer:        iss,
+		audience:      aud,
+		accessSecret:  []byte(as),
+		refreshSecret: []byte(rs),
+		clock:         clock,
+	}, nil
+}
+
+// トークンを生成する
+func (ts *TokenService) GenerateToken(id, uniqueName string) (string, string, error) {
+	accessToken, err := ts.generateAccessToken(id, uniqueName)
+	if err != nil {
+		return "", "", err
+	}
+	refreshToken, err := ts.generateRefreshToken(id)
+	if err != nil {
+		return "", "", err
+	}
+	return accessToken, refreshToken, nil
+}
+
+// アクセストークンを生成する
+func (ts *TokenService) generateAccessToken(id, uniqueName string) (string, error) {
+	jti := uuid.New().String()
+	claims := jwt.MapClaims{
+		"exp":   ts.clock.Now().Add(accessTokenExpire).Unix(),
+		"iat":   ts.clock.Now().Unix(),
+		"iss":   ts.issuer,
+		"sub":   id,
+		"aud":   ts.audience,
+		"jti":   jti,
+		"uname": uniqueName,
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+
+	tokenString, err := token.SignedString(ts.accessSecret)
+	if err != nil {
+		return "", err
+	}
+	if err := ts.store.SaveJTI(jti); err != nil {
+		return "", err
+	}
+
+	return tokenString, nil
+}
+
+// リフレッシュトークンを生成する
+func (ts *TokenService) generateRefreshToken(id string) (string, error) {
+	jti := uuid.New().String()
+	claims := jwt.MapClaims{
+		"exp": ts.clock.Now().Add(refreshTokenExpire).Unix(),
+		"iss": ts.issuer,
+		"sub": id,
+		"jti": jti,
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+
+	tokenString, err := token.SignedString(ts.refreshSecret)
+	if err != nil {
+		return "", err
+	}
+	if err := ts.store.SaveJTI(jti); err != nil {
+		return "", err
+	}
+
+	return tokenString, nil
+}
+
+func (ts *TokenService) ParseAccessToken(token string) (*Token, error) {
+	t, err := jwt.Parse(token, func(t *jwt.Token) (interface{}, error) {
+		if t.Method.Alg() != jwt.SigningMethodHS256.Alg() {
+			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+		}
+		return []byte(ts.accessSecret), nil
+	})
+
+	if claims, ok := t.Claims.(jwt.MapClaims); ok && t.Valid {
+		exp, err := claims.GetExpirationTime()
+		if err != nil {
+			return nil, err
+		}
+		expUTC := exp.Time.UTC()
+		iat, err := claims.GetIssuedAt()
+		if err != nil {
+			return nil, err
+		}
+		iatUTC := iat.Time.UTC()
+		iss, err := claims.GetIssuer()
+		if err != nil {
+			return nil, err
+		}
+		sub, err := claims.GetSubject()
+		if err != nil {
+			return nil, err
+		}
+		aud, err := claims.GetAudience()
+		if err != nil {
+			return nil, err
+		}
+		jti, ok := claims["jti"].(string)
+		if !ok {
+			return nil, errors.New("jti is not set")
+		}
+		uname, ok := claims["uname"].(string)
+		if !ok {
+			return nil, errors.New("uname is not set")
+		}
+		return &Token{
+			Exp:   expUTC,
+			Iat:   iatUTC,
+			Iss:   iss,
+			Sub:   sub,
+			Aud:   aud,
+			Jti:   jti,
+			Uname: uname,
+		}, nil
+	} else {
+		return nil, err
+	}
+}
+
+func (ts *TokenService) ParseRefreshToken(token string) (*Token, error) {
+	t, err := jwt.Parse(token, func(t *jwt.Token) (interface{}, error) {
+		if t.Method.Alg() != jwt.SigningMethodHS256.Alg() {
+			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+		}
+		return []byte(ts.accessSecret), nil
+	})
+
+	if claims, ok := t.Claims.(jwt.MapClaims); ok && t.Valid {
+		exp, err := claims.GetExpirationTime()
+		if err != nil {
+			return nil, err
+		}
+		expUTC := exp.Time.UTC()
+		iss, err := claims.GetIssuer()
+		if err != nil {
+			return nil, err
+		}
+		sub, err := claims.GetSubject()
+		if err != nil {
+			return nil, err
+		}
+		jti, ok := claims["jti"].(string)
+		if !ok {
+			return nil, errors.New("jti is not set")
+		}
+		return &Token{
+			Exp: expUTC,
+			Iss: iss,
+			Sub: sub,
+			Jti: jti,
+		}, nil
+	} else {
+		return nil, err
+	}
+}

--- a/backend/pkg/auth/token_test.go
+++ b/backend/pkg/auth/token_test.go
@@ -1,0 +1,70 @@
+package auth_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/yDog-1/wodun/backend/pkg/auth"
+)
+
+type mockTokenStore struct {
+}
+
+func (m mockTokenStore) SaveJTI(jti string) error {
+	return nil
+}
+func (m mockTokenStore) ExistsJTI(jti string) (bool, error) {
+	return false, nil
+}
+
+type mockClock struct{}
+
+// 2100-01-01 00:00:00 を返す
+func (c mockClock) Now() time.Time {
+	return time.Date(2100, 1, 1, 0, 0, 0, 0, time.UTC)
+}
+
+func Testトークンを生成する(t *testing.T) {
+	t.Setenv("TOKEN_ISSUER", "test")
+	t.Setenv("TOKEN_AUDIENCE", "test")
+	t.Setenv("TOKEN_ACCESS_SECRET", "test")
+	t.Setenv("TOKEN_REFRESH_SECRET", "test")
+	id := "1"
+	var store mockTokenStore
+	ts, err := auth.NewTokenService(store, mockClock{})
+	assert.Nil(t, err)
+	// トークンを生成する
+	accessToken, refreshToken, err := ts.GenerateToken(id, "user")
+	assert.NoError(t, err)
+
+	accessClaims, err := ts.ParseAccessToken(accessToken)
+	assert.NoError(t, err)
+	assert.Equal(t,
+		mockClock{}.Now().Add(time.Hour),
+		accessClaims.Exp,
+		"expが1時間後であること",
+	)
+	assert.Equal(t,
+		mockClock{}.Now(),
+		accessClaims.Iat,
+		"iatが現在時刻であること",
+	)
+	assert.Equal(t, "test", accessClaims.Iss)
+	assert.Equal(t, id, accessClaims.Sub)
+	assert.Equal(t, jwt.ClaimStrings{"test"}, accessClaims.Aud)
+	assert.NotEmpty(t, accessClaims.Jti)
+	assert.Equal(t, "user", accessClaims.Uname)
+
+	refreshClaims, err := ts.ParseRefreshToken(refreshToken)
+	assert.NoError(t, err)
+	assert.Equal(t,
+		mockClock{}.Now().Add(time.Hour*24*7),
+		refreshClaims.Exp,
+		"expが24時間後であること",
+	)
+	assert.Equal(t, "test", refreshClaims.Iss)
+	assert.Equal(t, id, refreshClaims.Sub)
+	assert.NotEmpty(t, refreshClaims.Jti)
+}

--- a/backend/pkg/clock.go
+++ b/backend/pkg/clock.go
@@ -1,0 +1,9 @@
+package pkg
+
+import "time"
+
+type Clock struct{}
+
+func (c Clock) Now() time.Time {
+	return time.Now()
+}


### PR DESCRIPTION
JWT認証のためのパッケージと、テストコードを実装。

`auth.clock` インターフェースの `Now()`メソッドにより現在時刻を取得している。